### PR TITLE
readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Note, if you're chatting with a database specifically, it will only be able to a
     ```
 3. Now, you can simply run the following to get started!
     ```
-    python streamlit app.py
+    streamlit app.py
     ```
 
 ## 🛠️ Upcoming features


### PR DESCRIPTION
**Why?** 
Application should start with `streamlit app.py`, not `python streamlit app.py`.

**What?**
- fix README.md with correct starting script

**How I tested**
![Screenshot from 2023-10-11 21-29-30](https://github.com/richieyoum/superknowba/assets/43356500/6d24d9a1-4dea-49f6-acf5-8635b4b5a619)
